### PR TITLE
Change print calls to log.info calls, get rid of bare try/except blocks

### DIFF
--- a/pmaw/Cache.py
+++ b/pmaw/Cache.py
@@ -16,7 +16,7 @@ class Cache(object):
         # generating key
         key_str = json.dumps(payload, sort_keys=True).encode("utf-8")
         self.key = hashlib.md5(key_str).hexdigest()
-        print(f'Response cache key: {self.key}')
+        log.info(f'Response cache key: {self.key}')
 
         # create cache folder
         self.folder = 'cache'
@@ -35,7 +35,7 @@ class Cache(object):
             num_resp = len(responses)
             checkpoint = len(self.response_cache) + 1
             self.size += num_resp
-            print(
+            log.info(
                 f'File Checkpoint {checkpoint}:: Caching {num_resp} Responses')
 
             filename = f'{checkpoint}-{self.key}-{num_resp}.pickle'

--- a/pmaw/Cache.py
+++ b/pmaw/Cache.py
@@ -49,7 +49,7 @@ class Cache(object):
         try:
             with open(f'./{self.folder}/{self.key}_info.pickle', 'rb') as handle:
                 return pickle.load(handle)
-        except:
+        except Exception:
             log.info('No previous requests to load')
 
     def load_resp(self, cache_num):

--- a/pmaw/Cache.py
+++ b/pmaw/Cache.py
@@ -16,7 +16,7 @@ class Cache(object):
         # generating key
         key_str = json.dumps(payload, sort_keys=True).encode("utf-8")
         self.key = hashlib.md5(key_str).hexdigest()
-        log.info(f'Response cache key: {self.key}')
+        print(f'Response cache key: {self.key}')
 
         # create cache folder
         self.folder = 'cache'

--- a/pmaw/PushshiftAPIBase.py
+++ b/pmaw/PushshiftAPIBase.py
@@ -191,7 +191,7 @@ class PushshiftAPIBase(object):
         elif prefix == 'Total':
             if remaining < 0:
                 remaining = 0  # don't print a neg number
-            log.info(
+            print(
                 f'{prefix}:: Success Rate: {rate:.2f}% - Requests: {self.num_req} - Batches: {self.num_batches} - Items Remaining: {remaining}')
 
     def _reset(self):
@@ -237,10 +237,10 @@ class PushshiftAPIBase(object):
                 total_avail = self.metadata_.get('total_results', 0)
 
                 if self.req.limit is None:
-                    log.info(f'{total_avail} result(s) available in Pushshift')
+                    print(f'{total_avail} result(s) available in Pushshift')
                     self.req.limit = total_avail
                 elif (total_avail < self.req.limit):
-                    log.info(f'{self.req.limit - total_avail} result(s) not found in Pushshift')
+                    print(f'{self.req.limit - total_avail} result(s) not found in Pushshift')
                     self.req.limit = total_avail
 
             # generate payloads

--- a/pmaw/PushshiftAPIBase.py
+++ b/pmaw/PushshiftAPIBase.py
@@ -1,15 +1,12 @@
 import time
-import datetime as dt
 import requests
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import copy
 import logging
-import warnings
 
 from pmaw.RateLimit import RateLimit
 from pmaw.Request import Request
-from pmaw.utils.slices import timeslice, mapslice
 
 log = logging.getLogger(__name__)
 
@@ -181,7 +178,7 @@ class PushshiftAPIBase(object):
         # shutdown executor
         try:
             exc.shutdown(wait=wait, cancel_futures=cancel_futures)
-        except:
+        except Exception:
             # TODO: manually cancel pending futures
             exc.shutdown(wait=wait)
 
@@ -189,12 +186,12 @@ class PushshiftAPIBase(object):
         rate = self.num_suc/self.num_req*100
         remaining = self.req.limit
         if (self.num_batches % self.checkpoint == 0) and prefix == 'Checkpoint':
-            print(
+            log.info(
                 f'{prefix}:: Success Rate: {rate:.2f}% - Requests: {self.num_req} - Batches: {self.num_batches} - Items Remaining: {remaining}')
         elif prefix == 'Total':
             if remaining < 0:
                 remaining = 0  # don't print a neg number
-            print(
+            log.info(
                 f'{prefix}:: Success Rate: {rate:.2f}% - Requests: {self.num_req} - Batches: {self.num_batches} - Items Remaining: {remaining}')
 
     def _reset(self):
@@ -240,10 +237,10 @@ class PushshiftAPIBase(object):
                 total_avail = self.metadata_.get('total_results', 0)
 
                 if self.req.limit is None:
-                    print(f'{total_avail} result(s) available in Pushshift')
+                    log.info(f'{total_avail} result(s) available in Pushshift')
                     self.req.limit = total_avail
                 elif (total_avail < self.req.limit):
-                    print(f'{self.req.limit - total_avail} result(s) not found in Pushshift')
+                    log.info(f'{self.req.limit - total_avail} result(s) not found in Pushshift')
                     self.req.limit = total_avail
 
             # generate payloads

--- a/pmaw/RateLimit.py
+++ b/pmaw/RateLimit.py
@@ -80,7 +80,7 @@ class RateLimit(object):
 
             try:
                 self.cache.remove(first_req)
-            except:
+            except Exception:
                 log.debug(f'{first_req} has already been removed RL cache')
 
             num_req = len(self.cache)

--- a/pmaw/Request.py
+++ b/pmaw/Request.py
@@ -42,7 +42,7 @@ class Request(object):
                     self.req_list.extend(info['req_list'])
                     self.payload = info['payload']
                     self.limit = info['limit']
-                    print(
+                    log.info(
                         f'Loaded Cache:: Responses: {self._cache.size} - Pending Requests: {len(self.req_list)} - Items Remaining: {self.limit}')
         else:
             self._cache = None
@@ -54,7 +54,7 @@ class Request(object):
         try:
             getattr(signal, 'SIGHUP')
             sigs = ('TERM', 'HUP', 'INT')
-        except:
+        except Exception:
             sigs = ('TERM', 'INT')
 
         for sig in sigs:
@@ -129,7 +129,7 @@ class Request(object):
                 all_ids = self.payload['ids']
                 if len(all_ids) == 0 and (self.limit and self.limit > 0):
                     warnings.warn(
-                        f'{self.limit} items were not found in Pushshift')                
+                        f'{self.limit} items were not found in Pushshift')
                 self.limit = len(all_ids)
 
                 # remove ids from payload to prevent , -> %2C and increasing query length

--- a/pmaw/Response.py
+++ b/pmaw/Response.py
@@ -50,8 +50,8 @@ class Response(Generator):
 
     def __len__(self):
         if self._cache:
-            length = len(self.responses) + self._cache.size - (self.i + self.num_returned) 
+            length = len(self.responses) + self._cache.size - (self.i + self.num_returned)
         else:
-            length = len(self.responses) - self.i  
-        
+            length = len(self.responses) - self.i
+
         return max(length, 0)


### PR DESCRIPTION
I think the end programmer should be able to configure what pmaw outputs to the terminal window, hence converting print calls to log.info calls. 

I've changed all blocks that look like 

```python
try:
    ...
except:
    ...
```

to 

```python
try:
    ...
except Exception:
    ...
```

This way we don't accidentally catch `KeyboardInterrupt` exceptions. 