### PR TITLE
2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .env
 pytest.ini
 pytest.log
+htmlcov
 
 pmaw.code-workspace
 pmaw.egg-info

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 2.1.0 (2021/09/30)
+
+- Updated logging and added `quiet_mode`
+- Added `load_cache` static method to `Response` to load cached responses using cache key
+
 ## 2.0.0 (2021/09/11)
 
 - Added support for enriching result metadata using PRAW

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-## 2.1.0 (2021/09/30)
+## 2.1.0 (2021/10/01)
 
-- Updated logging and added `quiet_mode`
+- Updated logging and set default log level to INFO
 - Added `load_cache` static method to `Response` to load cached responses using cache key
 
 ## 2.0.0 (2021/09/11)

--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ A user-defined function can be provided using the `filter_fn` parameter for eith
 - `limit_type` (str, optional): Type of rate limiting to use, options are 'average' for rate averaging, 'backoff' for exponential backoff. Defaults to 'average'.
 - `jitter` (str, optional): Jitter to use with backoff, options are None, 'full', 'equal', 'decorr'. Defaults to None.
 - `checkpoint` (int, optional): Size of interval in batches to print a checkpoint with stats, defaults to 10
-- `file_checkpoint` (int, optional) - Size of interval in batches to cache responses when using mem_safe, defaults to 20
-- `praw` (praw.Reddit, optional) - Used to enrich the Pushshift items retrieved with metadata directly from Reddit
+- `file_checkpoint` (int, optional): Size of interval in batches to cache responses when using mem_safe, defaults to 20
+- `praw` (praw.Reddit, optional): Used to enrich the Pushshift items retrieved with metadata directly from Reddit
+- `quiet_mode` (bool, optional): If true, only show set log level to WARN, defaults to INFO when False
 
 ### `Response`
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Introducing an element of randomness called `jitter` allows us to reduce the com
 - `decorr` - decorrelated jitter is similar to `full` jitter but increases the maximum jitter based on the last random value, selecting the length of sleep by the minimum value between `max_sleep` and a random sample between the `base_backoff` and the last sleep value multiplied by 3.
 
 ## Caching
+
 ### Memory Safety
 
 Memory safety allows us to reduce the amount of RAM used when requesting data, and can be enabled by setting `mem_safe=True` on a search method. This feature should be used if a large amount of data is being requested or if the machine in use has a limited amount of RAM.
@@ -159,7 +160,6 @@ A user-defined function can be provided using the `filter_fn` parameter for eith
 - `checkpoint` (int, optional): Size of interval in batches to print a checkpoint with stats, defaults to 10
 - `file_checkpoint` (int, optional): Size of interval in batches to cache responses when using mem_safe, defaults to 20
 - `praw` (praw.Reddit, optional): Used to enrich the Pushshift items retrieved with metadata directly from Reddit
-- `quiet_mode` (bool, optional): If true, only show set log level to WARN, defaults to INFO when False
 
 ### `Response`
 
@@ -357,7 +357,6 @@ cache_dir = './cache'
 resp = Response.load_cache(cache_key, cache_dir)
 
 ```
-
 
 # Benchmarks
 

--- a/pmaw/Cache.py
+++ b/pmaw/Cache.py
@@ -10,7 +10,6 @@ import gzip
 
 log = logging.getLogger(__name__)
 
-
 class Cache(object):
     """Cache: Handle storing and loading request info and responses in the cache"""
 
@@ -18,7 +17,7 @@ class Cache(object):
         # generating key
         key_str = json.dumps(payload, sort_keys=True).encode("utf-8")
         self.key = hashlib.md5(key_str).hexdigest()
-        print(f'Response cache key: {self.key}')
+        log.info(f'Response cache key: {self.key}')
 
         # create cache folder
         self.folder = str(cache_dir) if cache_dir else "./cache"
@@ -34,7 +33,7 @@ class Cache(object):
             num_resp = len(responses)
             checkpoint = len(self.response_cache) + 1
             self.size += num_resp
-            log.info(
+            log.debug(
                 f'File Checkpoint {checkpoint}:: Caching {num_resp} Responses')
 
             filename = f'{checkpoint}-{self.key}-{num_resp}.pickle.gz'
@@ -50,6 +49,7 @@ class Cache(object):
                 return pickle.load(handle)
         except FileNotFoundError:
             log.info('No previous requests to load')
+            return None
 
     def load_resp(self, cache_num):
         filename = self.response_cache[cache_num]

--- a/pmaw/Cache.py
+++ b/pmaw/Cache.py
@@ -13,11 +13,15 @@ log = logging.getLogger(__name__)
 class Cache(object):
     """Cache: Handle storing and loading request info and responses in the cache"""
 
-    def __init__(self, payload, safe_exit, cache_dir=None):
-        # generating key
-        key_str = json.dumps(payload, sort_keys=True).encode("utf-8")
-        self.key = hashlib.md5(key_str).hexdigest()
-        log.info(f'Response cache key: {self.key}')
+    def __init__(self, payload, safe_exit, cache_dir=None, key=None):
+
+        if key is None:
+            # generating key
+            key_str = json.dumps(payload, sort_keys=True).encode("utf-8")
+            self.key = hashlib.md5(key_str).hexdigest()
+            log.info(f'Response cache key: {self.key}')
+        else:
+            self.key = key
 
         # create cache folder
         self.folder = str(cache_dir) if cache_dir else "./cache"
@@ -27,6 +31,10 @@ class Cache(object):
         self.size = 0
         if safe_exit:
             self.check_cache()
+    
+    @staticmethod
+    def load_with_key(key, cache_dir=None):
+        return Cache({}, True, cache_dir, key)
 
     def cache_responses(self, responses):
         if responses:

--- a/pmaw/PushshiftAPI.py
+++ b/pmaw/PushshiftAPI.py
@@ -18,6 +18,7 @@ class PushshiftAPI(PushshiftAPIBase):
             checkpoint (int, optional) - Size of interval in batches to print a checkpoint with stats, defaults to 10
             file_checkpoint (int, optional) - Size of interval in batches to cache responses when using mem_safe, defaults to 20
             praw (praw.Reddit, optional) - Used to enrich the Pushshift items retrieved with metadata directly from Reddit
+            quiet_mode (bool, optional) - If true, only show set log level to WARN, defaults to INFO when False
         """
         super().__init__(*args, **kwargs)
 

--- a/pmaw/PushshiftAPI.py
+++ b/pmaw/PushshiftAPI.py
@@ -18,7 +18,6 @@ class PushshiftAPI(PushshiftAPIBase):
             checkpoint (int, optional) - Size of interval in batches to print a checkpoint with stats, defaults to 10
             file_checkpoint (int, optional) - Size of interval in batches to cache responses when using mem_safe, defaults to 20
             praw (praw.Reddit, optional) - Used to enrich the Pushshift items retrieved with metadata directly from Reddit
-            quiet_mode (bool, optional) - If true, only show set log level to WARN, defaults to INFO when False
         """
         super().__init__(*args, **kwargs)
 

--- a/pmaw/PushshiftAPIBase.py
+++ b/pmaw/PushshiftAPIBase.py
@@ -10,15 +10,15 @@ from requests import HTTPError
 from pmaw.RateLimit import RateLimit
 from pmaw.Request import Request
 
+logging.basicConfig(level = logging.INFO, stream=sys.stdout)
 log = logging.getLogger(__name__)
-
 
 class PushshiftAPIBase(object):
     _base_url = 'https://{domain}.pushshift.io/{{endpoint}}'
 
     def __init__(self, num_workers=10, max_sleep=60, rate_limit=60, base_backoff=0.5,
                  batch_size=None, shards_down_behavior='warn', limit_type='average', jitter=None,
-                 checkpoint=10, file_checkpoint=20, praw=None, quiet_mode=False):
+                 checkpoint=10, file_checkpoint=20, praw=None):
         self.num_workers = num_workers
         self.domain = 'api'
         self.shards_down_behavior = shards_down_behavior
@@ -27,9 +27,6 @@ class PushshiftAPIBase(object):
         self.checkpoint = checkpoint
         self.file_checkpoint = file_checkpoint
         self.praw = praw
-
-        log_level = logging.WARN if quiet_mode else logging.INFO
-        logging.basicConfig(level = log_level, stream=sys.stdout)
 
         if batch_size:
             self.batch_size = batch_size

--- a/pmaw/Request.py
+++ b/pmaw/Request.py
@@ -71,7 +71,7 @@ class Request(object):
             self._cache = Cache(_tmp, safe_exit, cache_dir=cache_dir)
             if safe_exit:
                 info = self._cache.load_info()
-                if info:
+                if info is not None:
                     self.req_list.extend(info['req_list'])
                     self.payload = info['payload']
                     self.limit = info['limit']

--- a/pmaw/Response.py
+++ b/pmaw/Response.py
@@ -1,6 +1,8 @@
 import logging
 from collections.abc import Generator
 
+from pmaw.Cache import Cache
+
 log = logging.getLogger(__name__)
 
 
@@ -15,6 +17,20 @@ class Response(Generator):
         # indexing for returning responses
         self.i = 0
         self.num_cache = 0
+    
+    @staticmethod
+    def load_cache(key, cache_dir=None):
+        """
+        Return an instance of Response with the results stored with the provided key
+
+        Input:
+            key (str) - Cache key for results to load into Response
+            cache_dir (str, optional) - An absolute or relative folder path to load cached responses from, defaults to './cache'
+        Output:
+            Response generator object
+        """
+        cache = Cache.load_with_key(key, cache_dir)
+        return Response(cache)
 
     def to_cache(self):
         self._cache.cache_responses(self.responses)

--- a/pmaw/__init__.py
+++ b/pmaw/__init__.py
@@ -5,7 +5,7 @@
 """
 PMAW: Pushshift Multithread API Wrapper
 """
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 __author__ = 'Matthew Podolak'
 __license__ = 'MIT'
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     url="https://github.com/mattpodolak/pmaw",
     packages=setuptools.find_packages(),
     license='MIT License',
-    install_requires=['requests'],
+    install_requires=['requests', 'praw'],
     keywords='reddit api wrapper pushshift multithread data collection cache',
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,6 @@
+from pmaw import Cache
+
+def test_no_info():
+  cache = Cache({}, False, cache_dir='./rand_cache')
+  info = cache.load_info()
+  assert(info == None)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -8,9 +8,9 @@ def test_safe_exit_praw():
     api_praw = PushshiftAPI(praw=reddit)
     comments = api_praw.search_comments(ids=comment_ids, safe_exit=True)
 
-@tape.use_cassette('test_submission_search_ids')
+@tape.use_cassette('test_comment_search_limit')
 def test_asc_sort():
   with pytest.raises(NotImplementedError):
     api = PushshiftAPI()
-    posts = api.search_submissions(ids=post_ids, sort='asc')
+    comments = api.search_comments(subreddit="science", limit=100, before=1629990795, sort='asc')
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,0 +1,16 @@
+from .config import tape, reddit, post_ids, comment_ids
+from pmaw import PushshiftAPI
+import pytest
+
+@tape.use_cassette('test_comment_praw_ids')
+def test_safe_exit_praw():
+  with pytest.raises(NotImplementedError):
+    api_praw = PushshiftAPI(praw=reddit)
+    comments = api_praw.search_comments(ids=comment_ids, safe_exit=True)
+
+@tape.use_cassette('test_submission_search_ids')
+def test_asc_sort():
+  with pytest.raises(NotImplementedError):
+    api = PushshiftAPI()
+    posts = api.search_submissions(ids=post_ids, sort='asc')
+

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -13,4 +13,4 @@ def test_response_generator():
   api = PushshiftAPI(file_checkpoint=1)
   comments = api.search_submission_comment_ids(ids=post_ids, mem_safe=True)
   all_c = [c for c in comments]
-  assert(len(comments) == len(all_c) and len(all_c) == 66)
+  assert(len(all_c) == 66)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,0 +1,16 @@
+from .config import tape, reddit, post_ids, comment_ids
+from pmaw import Response, PushshiftAPI
+
+@tape.use_cassette('test_submission_comment_ids_search')
+def test_response_load_cache():
+  api = PushshiftAPI(file_checkpoint=1)
+  comments = api.search_submission_comment_ids(ids=post_ids, mem_safe=True)
+  resp = Response.load_cache(key=comments._cache.key)
+  assert(len(comments) == len(resp) and len(comments) == 66)
+
+@tape.use_cassette('test_submission_comment_ids_search')
+def test_response_generator():
+  api = PushshiftAPI(file_checkpoint=1)
+  comments = api.search_submission_comment_ids(ids=post_ids, mem_safe=True)
+  all_c = [c for c in comments]
+  assert(len(comments) == len(all_c) and len(all_c) == 66)


### PR DESCRIPTION
- Updated logging and set default log level to INFO 
- fixed issue with no logs when loading cache (#25 )
- Added `load_cache` static method to `Response` to load cached responses using cache key