### PR TITLE
fix: result is reported but cannot be returned by Pushshift

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 2.1.2 (2022/01/07)
+
+- fix scenario where a result is reported but cannot be returned by Pushshift
+
 ## 2.1.1 (2021/11/29)
 
 - fix index error bug

--- a/pmaw/PushshiftAPIBase.py
+++ b/pmaw/PushshiftAPIBase.py
@@ -167,14 +167,14 @@ class PushshiftAPIBase(object):
 
                         if num > 0:
                             # find minimum `created_utc` to set as the `before` parameter in next timeslices
+                            # Fix issue where Pushshift occasionally reports remaining results that it is
+                            # unable to return - len(data) == 0 when this happens                    
                             if len(data) > 0:
-                                # make sure that index error wont occur
-                                # we want to slice using the payload['before'] if we dont get any results
                                 before = data[-1]['created_utc']
+                                # generate payloads
+                                self.req.gen_slices(
+                                    url, payload, after, before, num)
 
-                            # generate payloads
-                            self.req.gen_slices(
-                                url, payload, after, before, num)
             except HTTPError as exc:
                 log.debug(f"Request Failed -- {exc}")
                 self._rate_limit._req_fail()

--- a/pmaw/__init__.py
+++ b/pmaw/__init__.py
@@ -1,11 +1,11 @@
 # PMAW
-# Copyright 2021 Matthew Podolak
+# Copyright 2022 Matthew Podolak
 # See LICENSE for details.
 
 """
 PMAW: Pushshift Multithread API Wrapper
 """
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 __author__ = 'Matthew Podolak'
 __license__ = 'MIT'
 


### PR DESCRIPTION
### Bug
- sometimes Pushshift reports additional remaining results for a query that it is unable to return, this causes `pmaw` to continue retrying queries infinitely 

### Fix
- check that the length of results returned is > 0 before generating additional payloads. We can conclude that if Pushshift returns 0 while reporting that there are results remaining that the results remaining are unavailable

### Linked Issues(s)
- #38