### PR TITLE
Python 3 updates; don't automatically configure logging

### DIFF
--- a/pmaw/Cache.py
+++ b/pmaw/Cache.py
@@ -10,7 +10,7 @@ import gzip
 
 log = logging.getLogger(__name__)
 
-class Cache(object):
+class Cache:
     """Cache: Handle storing and loading request info and responses in the cache"""
 
     def __init__(self, payload, safe_exit, cache_dir=None, key=None):

--- a/pmaw/PushshiftAPI.py
+++ b/pmaw/PushshiftAPI.py
@@ -1,5 +1,6 @@
 from pmaw.PushshiftAPIBase import PushshiftAPIBase
 
+
 class PushshiftAPI(PushshiftAPIBase):
     def __init__(self, *args, **kwargs):
         """

--- a/pmaw/PushshiftAPIBase.py
+++ b/pmaw/PushshiftAPIBase.py
@@ -10,10 +10,11 @@ from requests import HTTPError
 from pmaw.RateLimit import RateLimit
 from pmaw.Request import Request
 
-logging.basicConfig(level = logging.INFO, stream=sys.stdout)
+
 log = logging.getLogger(__name__)
 
-class PushshiftAPIBase(object):
+
+class PushshiftAPIBase:
     _base_url = 'https://{domain}.pushshift.io/{{endpoint}}'
 
     def __init__(self, num_workers=10, max_sleep=60, rate_limit=60, base_backoff=0.5,

--- a/pmaw/RateLimit.py
+++ b/pmaw/RateLimit.py
@@ -5,7 +5,7 @@ import random
 log = logging.getLogger(__name__)
 
 
-class RateLimit(object):
+class RateLimit:
     """RateLimit: Implements different rate-limiting strategies for concurrent requests"""
 
     def __init__(self, rate_limit=60, base_backoff=0.5, limit_type='average', max_sleep=60, jitter=None):

--- a/pmaw/Request.py
+++ b/pmaw/Request.py
@@ -18,7 +18,7 @@ from pmaw.Response import Response
 log = logging.getLogger(__name__)
 
 
-class Request(object):
+class Request:
     """Request: Handles request information, response saving, and cache usage."""
 
     def __init__(self, payload, filter_fn, kind, max_results_per_request, max_ids_per_request, mem_safe, safe_exit, cache_dir=None, praw=None):


### PR DESCRIPTION
Two small updates: 
- Don't inherit from `object` in classes; this is unnecessary in Python3 
- Don't automatically configure logging. Configuring logging inside a library leads to unexpected results when end users try to configure logging on their own. 