### PR TITLE
Support for Pushshift switchover to COLO (as of 2022-12)

### DIFF
--- a/pmaw/PushshiftAPI.py
+++ b/pmaw/PushshiftAPI.py
@@ -19,6 +19,8 @@ class PushshiftAPI(PushshiftAPIBase):
             checkpoint (int, optional) - Size of interval in batches to print a checkpoint with stats, defaults to 10
             file_checkpoint (int, optional) - Size of interval in batches to cache responses when using mem_safe, defaults to 20
             praw (praw.Reddit, optional) - Used to enrich the Pushshift items retrieved with metadata directly from Reddit
+            sort_var (str, optional) - parameter, used in Pushshift API, to sort values
+            check_totals (bool, optional) - if to check total counts before returning results. API stopped returning total counts as of 2022-12-17
         """
         super().__init__(*args, **kwargs)
 
@@ -32,6 +34,8 @@ class PushshiftAPI(PushshiftAPIBase):
             mem_safe (boolean, optional) - If True, stores responses in cache during operation, defaults to False
             safe_exit (boolean, optional) - If True, will safely exit if interrupted by storing current responses and requests in the cache. Will also load previous requests / responses if found in cache, defaults to False
             cache_dir (str, optional) - An absolute or relative folder path to cache responses in when mem_safe or safe_exit is enabled
+            sort_var (str, optional) - parameter, used in Pushshift API, to sort values
+            check_totals (bool, optional) - if to check total counts before returning results. API stopped returning total counts as of 2022-12-17
         Output:
             Response generator object
         """
@@ -52,6 +56,8 @@ class PushshiftAPI(PushshiftAPIBase):
             safe_exit (boolean, optional) - If True, will safely exit if interrupted by storing current responses and requests in the cache. Will also load previous requests / responses if found in cache, defaults to False
             filter_fn (function, optional) - A function used for custom filtering the results before saving them. Accepts a single comment parameter and returns False to filter out the item, otherwise returns True.
             cache_dir (str, optional) - An absolute or relative folder path to cache responses in when mem_safe or safe_exit is enabled
+            sort_var (str, optional) - parameter, used in Pushshift API, to sort values
+            check_totals (bool, optional) - if to check total counts before returning results. API stopped returning total counts as of 2022-12-17
         Output:
             Response generator object
         """
@@ -69,6 +75,8 @@ class PushshiftAPI(PushshiftAPIBase):
             safe_exit (boolean, optional) - If True, will safely exit if interrupted by storing current responses and requests in the cache. Will also load previous requests / responses if found in cache, defaults to False
             filter_fn (function, optional) - A function used for custom filtering the results before saving them. Accepts a single submission parameter and returns False to filter out the item, otherwise returns True.
             cache_dir (str, optional) - An absolute or relative folder path to cache responses in when mem_safe or safe_exit is enabled
+            sort_var (str, optional) - parameter, used in Pushshift API, to sort values
+            check_totals (bool, optional) - if to check total counts before returning results. API stopped returning total counts as of 2022-12-17
         Output:
             Response generator object
         """

--- a/pmaw/Request.py
+++ b/pmaw/Request.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 class Request:
     """Request: Handles request information, response saving, and cache usage."""
 
-    def __init__(self, payload, filter_fn, kind, max_results_per_request, max_ids_per_request, mem_safe, safe_exit, cache_dir=None, praw=None):
+    def __init__(self, payload, filter_fn, kind, max_results_per_request, max_ids_per_request, mem_safe, safe_exit, cache_dir=None, praw=None, sort_var='sort'):
         self.kind = kind
         self.max_ids_per_request = min(500, max_ids_per_request)
         self.max_results_per_request = min(100, max_results_per_request)
@@ -32,7 +32,9 @@ class Request:
         self.limit = payload.get('limit', None)
         self.exit = Event()
         self.praw = praw
+        self.sort_var = sort_var
         self._filter = filter_fn
+
 
         if filter_fn is not None and not callable(filter_fn):
             raise ValueError('filter_fn must be a callable function')
@@ -185,9 +187,9 @@ class Request:
 
         payload['size'] = self.max_results_per_request
 
-        if 'sort' not in payload:
-            payload['sort'] = 'desc'
-        elif payload.get('sort') != 'desc':
+        if self.sort_var not in payload:
+            payload[self.sort_var] = 'desc'
+        elif payload.get(self.sort_var) != 'desc':
             err_msg = "Support for non-default sort has not been implemented as it may cause unexpected results"
             raise NotImplementedError(err_msg)
 


### PR DESCRIPTION
Just a quick temporary fix
TL;DR:
Added two parameters: _sort_var_ and _check_totals_ to API calls; add variables `sort_var='order', check_totals=False` while calling `search_submissions` or any other function for it to work with the latest data in Pushshift

Longer version:

After moving to COLO (related Reddit post is [here](https://www.reddit.com/r/pushshift/comments/zkggt0/update_on_colo_switchover_bug_fixes_reindexing/)), The current wrapper stopped working.
Known differences:
* _order_ instead of _sort_ parameter to sort data in the response (added parameter sort_var, defaults to older _sort_, but can be replaced to _order_ in API call functions)
* the metadata (including the total number of items in the database) is not returned anymore, therefore added a parameter _check_totals_, where _False_ value will skip checking it (can cause a discrepancy in data)