### PR TITLE
set a default level and a default handler

### DIFF
--- a/pmaw/PushshiftAPIBase.py
+++ b/pmaw/PushshiftAPIBase.py
@@ -12,7 +12,7 @@ from pmaw.Request import Request
 
 
 log = logging.getLogger(__name__)
-
+logging.basicConfig(level=logging.INFO)
 
 class PushshiftAPIBase:
     _base_url = "https://{domain}.pushshift.io/{{endpoint}}"


### PR DESCRIPTION
Solve the problem of not having the logs for progress despite having the code to print the logs.